### PR TITLE
Fix missing/wrong links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -98,10 +98,10 @@
             </tr>
             <tr>
               <td class="px-4 py-3">netCDF</td>
-              <td class="px-4 py-3 font-normal">Bindings for Network Common Data Form (NetCDF) library. Can read and
+              <td class="px-4 py-3 font-normal">Bindings for Network Common Data Form (netCDF) library. Can read and
                 write HDF5 files.</td>
-              <td class="px-4 py-3 text-indigo-900"><a href="https://github.com/georust/geotiff">GitHub</a></td>
-              <td class="px-4 py-3 text-indigo-900"><a href="https://crates.io/crates/geotiff">crates.io</a></td>
+              <td class="px-4 py-3 text-indigo-900"><a href="https://github.com/georust/netcdf">GitHub</a></td>
+              <td class="px-4 py-3 text-indigo-900"><a href="https://crates.io/crates/netcdf">crates.io</a></td>
             </tr>
             <tr>
               <td class="px-4 py-3">OSM</td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -76,7 +76,7 @@
               <td class="w-3/6 px-4 py-3 font-normal">Bindings for the Geographic Data Abstraction Library (GDAL) for
                 reading and writing raster and vector GIS files.</td>
               <td class="w-1/6 px-4 py-3 text-indigo-900"><a href="https://github.com/georust/gdal">GitHub</a></td>
-              <td class="w-1/6 px-4 py-3 text-indigo-900"><a href="https://crates.io/crates/">crates.io</a></td>
+              <td class="w-1/6 px-4 py-3 text-indigo-900"><a href="https://crates.io/crates/gdal">crates.io</a></td>
             </tr>
             <tr>
               <td class="px-4 py-3">GeoJSON</td>


### PR DESCRIPTION
Thanks for making the webpage, it's looking awesome!

Seems the wrong repo was linked for `netCDF`, which instead linked to `geotiff`. GDAL was also missing a link to the corresponding `crates.io` entry