### PR TITLE
Add a link to book.georust.org, add descriptions for links and update design to accommodate it.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,10 +24,15 @@
 
   <div class="container mx-auto">
     <div class="flex flex-wrap mx-auto justify-center text-2xl text-white font-black mt-4 mb-10 px-4">
-      <div class="flex bg-indigo-900 rounded-lg shadow-md px-4 py-2 m-4"><a href="https://github.com/georust">GitHub</a>
+      <div class="flex bg-indigo-900 rounded-lg shadow-md px-4 py-2 m-4">
+          <a href="https://github.com/georust">GitHub</a>
       </div>
-      <div class="flex bg-indigo-900 rounded-lg shadow-md ml-4 px-4 py-2 m-4"><a
-          href="https://discord.gg/Fp2aape">Discord</a></div>
+      <div class="flex bg-indigo-900 rounded-lg shadow-md ml-4 px-4 py-2 m-4">
+          <a href="https://discord.gg/Fp2aape">Discord</a>
+      </div>
+      <div class="flex bg-indigo-900 rounded-lg shadow-md ml-4 px-4 py-2 m-4">
+          <a href="https://book.georust.org">Book</a>
+      </div>
     </div>
   </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,16 +25,27 @@
   <div class="container mx-auto">
     <div class="flex flex-wrap mx-auto justify-center text-2xl mt-4 mb-10 px-4">
       <div class="flex-col">
-          <a class="bg-indigo-900 text-white font-black rounded-lg shadow-md px-4 py-2 m-4" href="https://github.com/georust">GitHub</a>
-          <p>Development occurs on Github across many project repositories.</p>
-      </div>
-      <div class="flex-col">
-          <a class="bg-indigo-900 text-white font-black rounded-lg shadow-md ml-4 px-4 py-2 m-4" href="https://discord.gg/Fp2aape">Discord</a>
-          <p>Ask questions or chat with us on Discord.</p>
-      </div>
-      <div class="flex-col">
-          <a class="bg-indigo-900 text-white font-black rounded-lg shadow-md ml-4 px-4 py-2 m-4" href="https://book.georust.org">Book</a>
-          <p>New to Rust or Geospatial? Check out this light hearted introduction.</p>
+        <p class="my-8">
+          Development occurs on
+          <a class="bg-indigo-900 text-white font-black rounded-lg shadow-md px-4 py-2" style="margin-right: 6px;" href="https://github.com/georust">
+            GitHub
+          </a>
+          across many project repositories.
+        </p>
+
+        <p style="margin-top: 12px;">
+          Ask questions or chat with us on
+          <a class="bg-indigo-900 text-white font-black rounded-lg shadow-md px-4 py-2" href="https://discord.gg/Fp2aape">
+            Discord
+          </a>.
+        </p>
+
+        <p style="margin-top: 12px;">
+          New to Rust or Geospatial? Check out
+          <a class="bg-indigo-900 text-white font-black rounded-lg shadow-md px-4 py-2" style="margin-right: 6px;" href="https://book.georust.org">
+            The Book
+          </a> for a lighthearted introduction.
+        </p>
       </div>
     </div>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
 </head>
 
 <body class="bg-gray-100">
-  <div class="flex justify-center py-12">
+  <div class="flex justify-center py-8">
     <a href="https://github.com/georust">
       <img class="h-56" src="logo.png" alt="Logo">
     </a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,23 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>GeoRust</title>
   <link rel="stylesheet" href="./css/tailwind.css">
+  <style>
+    h1 {
+        font-weight: bold;
+        font-size: 200%;
+    }
+    h2 {
+        font-weight: bold;
+        font-size: 125%;
+    }
+    body {
+        color: #1a202c;
+        font-size: 150%;
+    }
+    a {
+        text-decoration: underline;
+    }
+  </style>
 </head>
 
 <body class="bg-gray-100">
@@ -17,40 +34,38 @@
     <br>
   </div>
 
-  <h1 class="text-6xl font-bold text-center text-gray-900">GeoRust</h1>
-  <p class="text-xl mt-2 text-center text-gray-900">
-    An ecosystem of geospatial tools and libraries written in Rust.
-  </p>
+  <h1 style="text-align: center;">GeoRust</h1>
+  <p style="text-align: center;">An ecosystem of geospatial tools and libraries written in Rust.</p>
 
-  <div class="container mx-auto">
-    <div class="flex flex-wrap mx-auto justify-center text-2xl mt-4 mb-10 px-4">
+  <div class="container mx-auto" style="margin-top: 40px;">
+    <div class="flex flex-wrap mx-auto justify-center mt-4 mb-10 px-4">
       <div class="flex-col">
-        <p class="my-8">
-          Development occurs on
-          <a class="bg-indigo-900 text-white font-black rounded-lg shadow-md px-4 py-2" style="margin-right: 6px;" href="https://github.com/georust">
-            GitHub
-          </a>
-          across many project repositories.
-        </p>
-
-        <p style="margin-top: 12px;">
-          Ask questions or chat with us on
-          <a class="bg-indigo-900 text-white font-black rounded-lg shadow-md px-4 py-2" href="https://discord.gg/Fp2aape">
+        <p>
+          👋 Say hello or ask questions on
+          <a href="https://discord.gg/Fp2aape">
             Discord
           </a>.
         </p>
 
-        <p style="margin-top: 12px;">
-          New to Rust or Geospatial? Check out
-          <a class="bg-indigo-900 text-white font-black rounded-lg shadow-md px-4 py-2" style="margin-right: 6px;" href="https://book.georust.org">
-            The Book
-          </a> for a lighthearted introduction.
+        <p>
+          💻 Development occurs on
+          <a href="https://github.com/georust">
+            GitHub
+          </a>
+          across per-project repositories.
+        </p>
+
+        <p>
+          📗 Check out
+          <a href="https://book.georust.org">
+            the book
+          </a> for a lighthearted introduction to Rust and Geospatial.
         </p>
       </div>
     </div>
   </div>
 
-  <div class="container mx-auto px-10 text-2xl text-gray-900">
+  <div class="container mx-auto px-10">
     <div class="flex-col mx-auto justify-center max-w-3xl">
       <div>
         <p class="font-black">Primitives</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,15 +23,18 @@
   </p>
 
   <div class="container mx-auto">
-    <div class="flex flex-wrap mx-auto justify-center text-2xl text-white font-black mt-4 mb-10 px-4">
-      <div class="flex bg-indigo-900 rounded-lg shadow-md px-4 py-2 m-4">
-          <a href="https://github.com/georust">GitHub</a>
+    <div class="flex flex-wrap mx-auto justify-center text-2xl mt-4 mb-10 px-4">
+      <div class="flex-col">
+          <a class="bg-indigo-900 text-white font-black rounded-lg shadow-md px-4 py-2 m-4" href="https://github.com/georust">GitHub</a>
+          <p>Development occurs on Github across many project repositories.</p>
       </div>
-      <div class="flex bg-indigo-900 rounded-lg shadow-md ml-4 px-4 py-2 m-4">
-          <a href="https://discord.gg/Fp2aape">Discord</a>
+      <div class="flex-col">
+          <a class="bg-indigo-900 text-white font-black rounded-lg shadow-md ml-4 px-4 py-2 m-4" href="https://discord.gg/Fp2aape">Discord</a>
+          <p>Ask questions or chat with us on Discord.</p>
       </div>
-      <div class="flex bg-indigo-900 rounded-lg shadow-md ml-4 px-4 py-2 m-4">
-          <a href="https://book.georust.org">Book</a>
+      <div class="flex-col">
+          <a class="bg-indigo-900 text-white font-black rounded-lg shadow-md ml-4 px-4 py-2 m-4" href="https://book.georust.org">Book</a>
+          <p>New to Rust or Geospatial? Check out this light hearted introduction.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Before
<img width="965" alt="Screen Shot 2022-10-04 at 6 18 42 PM" src="https://user-images.githubusercontent.com/217057/193959352-6dec4f74-e4a7-480a-b930-f3997cfb7083.png">

## After

### after: desktop
<img width="927" alt="Screen Shot 2022-10-04 at 6 24 06 PM" src="https://user-images.githubusercontent.com/217057/193959427-fb03ea3c-97e2-4b7f-901e-057417fba53b.png">

### after: mobile
<img width="286" alt="Screen Shot 2022-10-04 at 6 22 24 PM" src="https://user-images.githubusercontent.com/217057/193959339-77693c94-c867-4f88-8527-eec6f035f0a7.png">

## failed experiment: minimalistic addition
<img width="1035" alt="Screen Shot 2022-10-04 at 6 19 25 PM" src="https://user-images.githubusercontent.com/217057/193959348-38eead27-581f-45bd-afa8-bfda77f3aabd.png">

It looks nice, but I felt like users would benefit from a little explanation of what the book is, but the current design doesn't really accommodate adding text.

## failed experiment: description with big chonky button links

<img width="1018" alt="Screen Shot 2022-10-04 at 6 19 48 PM" src="https://user-images.githubusercontent.com/217057/193959346-37ca1dd4-851b-455f-9856-11bab6c9ab86.png">
