### PR TITLE
Fix typo (OpenStreetMap is singular)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -151,7 +151,7 @@
             </tr>
             <tr>
               <td class="px-4 py-3">OSM</td>
-              <td class="px-4 py-3 font-normal">Work with the OpenStreetMaps PBF files.</td>
+              <td class="px-4 py-3 font-normal">Work with OpenStreetMap PBF files.</td>
               <td class="px-4 py-3 text-indigo-900"><a href="https://github.com/georust/osm">GitHub</a></td>
               <td class="px-4 py-3 text-indigo-900"><a href="https://crates.io/crates/osm">crates.io</a></td>
             </tr>


### PR DESCRIPTION
This fixes a typo I noticed on georust.org (OpenStreetMap is singular, not plural). Also dropped the "the" in front of it which isn't typically used.